### PR TITLE
Match sidebar colour header to app

### DIFF
--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -2,10 +2,12 @@ import BackIcon from '@mui/icons-material/ArrowBackIos';
 import MailIcon from '@mui/icons-material/Mail';
 import InboxIcon from '@mui/icons-material/MoveToInbox';
 import { Divider, Drawer, IconButton, List, ListItemButton, ListItemIcon, ListItemText, Toolbar } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 
 const drawerWidth = 240;
 
 const Sidebar = () => {
+    const theme = useTheme();
     return (
         <Drawer
             variant="persistent"
@@ -20,7 +22,7 @@ const Sidebar = () => {
                 },
             }}
         >
-            <Toolbar className='h-16 flex justify-end'>
+            <Toolbar className='h-16 flex justify-end' style={{ backgroundColor: theme.palette.primary.main }}>
                 <IconButton><BackIcon /></IconButton>
             </Toolbar>
             <Divider />


### PR DESCRIPTION
- using UseTheme hook to set sidebar colour based on app primary colour